### PR TITLE
UPI Support + credentials management

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,80 @@ cluster is expected to be destroyed at the end of a test run.
 To automatically destroy a cluster if creation fails, set
 `ocp_install_destroy_cluster_on_failure` to `true` as described in the previous section.
 
+### Credentials Installation
+
+For each platform, `openshift-install` looks for that platform's credentials in a specific
+and predictable location. Each platform's credentials file can be installed by naming a
+file local to the Ansible control machine to use in that platform's corresponding 
+`ocp_install_*_creds_file` role variable. **Note that credentials files on the target
+machine(s) will be overwritten when configured to do so with these variables.**
+
+When not provided via the OpenShift Container Platform installation documentation,
+example credentials files have been provided.
+
+#### AWS
+
+* `ocp_install_aws_creds_file` - Credentials file on Ansible control machine to copy to
+  the host running `openshift-install` to allow the installer to access this platform,
+  containing an AWS account access key pair.
+
+Example Format:
+```ini
+; https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html
+[default]
+aws_access_key_id     = your_access_key_id_here
+aws_secret_access_key = your_secret_access_key_here
+```
+
+#### Azure
+
+* `ocp_install_azure_creds_file` - Credential file on Ansible control machine to copy to
+  the host running `openshift-install` to allow the installer to access this platform,
+  containing Azure Service Principal credentials.
+
+Example Format:
+```
+{
+    "subscriptionId": "put",
+    "clientId": "your",
+    "clientSecret": "credentials",
+    "tenantId": "here"
+}
+```
+
+#### GCP
+
+* `ocp_install_gcp_creds_file` - Credential file on Ansible control machine to copy to
+  the host running `openshift-install` to allow the installer to access this platform,
+  containing GCP Service Account credentials.
+
+Example Format:
+```yaml
+{
+  "type": "service_account",
+  "project_id": "project",
+  "private_key_id": "0000000000000000000000000000000000000000",
+  "private_key": "-----BEGIN PRIVATE KEY-----\n...\n",
+  "client_email": "your@project.iam.gserviceaccount.com",
+  "client_id": "12345",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/your%40project.iam.gserviceaccount.com"
+}
+```
+
+#### OpenStack
+
+* `ocp_install_openstack_creds_file` - Credential file on Ansible control machine to copy
+  to the host running `openshift-install` to allow the install access to this platform,
+  which is expected to be a working [clouds.yaml] file.
+
+Splitting secrets is not supported by this role; only `clouds.yaml` is supported, not
+`secure.yaml`. The cloud, or one of the clouds, defined in this file should match the 
+cloud named in the `ocp_install_platform`, and other `install-config.yaml` values that
+reference OpenStack clouds by their defined name in `clouds.yaml`.
+
 ### async
 
 Because both the `create cluster` and `destroy cluster` commands take a while to run, and
@@ -258,3 +332,4 @@ Sean Myers <semyers@redhat.com>
 [openshift-install customization]: https://github.com/openshift/installer/blob/master/docs/user/customization.md#platform-customization
 [index_href]: https://github.com/oasis-roles/index_href
 [ocp_pull_secrets]: https://github.com/oasis-roles/ocp_pull_secrets
+[clouds.yaml]: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.2/html/installing_on_openstack/installing-on-openstack#installation-osp-describing-cloud-parameters_installing-openstack-installer-custom

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,8 @@ ocp_install_config_template: ocp_install_default_config.yaml
 ocp_install_generate_config: false
 ocp_install_create_cluster: false
 ocp_install_destroy_cluster: false
+ocp_install_create_manifests: false
+ocp_install_create_ignition_configs: false
 ocp_install_log_level: info
 ocp_install_destroy_cluster_on_failure: false
 ocp_install_async_timeout: 3600

--- a/tasks/create_ignition_configs.yml
+++ b/tasks/create_ignition_configs.yml
@@ -1,0 +1,6 @@
+- name: Run openshift-install create ignition-configs
+  command: >-
+    {{ ocp_install_path }}/openshift-install create ignition-configs
+    --dir "{{ ocp_install_config_dir }}"
+    --log-level "{{ ocp_install_log_level }}"
+  when: ocp_install_create_ignition_configs

--- a/tasks/create_manifests.yml
+++ b/tasks/create_manifests.yml
@@ -1,0 +1,6 @@
+- name: Run openshift-install create manifests
+  command: >-
+    {{ ocp_install_path }}/openshift-install create manifests
+    --dir "{{ ocp_install_config_dir }}"
+    --log-level "{{ ocp_install_log_level }}"
+  when: ocp_install_create_manifests

--- a/tasks/credentials_aws.yml
+++ b/tasks/credentials_aws.yml
@@ -1,0 +1,9 @@
+- name: Create destination directory for AWS Credentials
+  file:
+    state: directory
+    dest: "{{ ocp_install_aws_creds_dest | dirname }}"
+
+- name: Install AWS Credentials for openshift-install
+  copy:
+    src: "{{ ocp_install_aws_creds_file }}"
+    dest: "{{ ocp_install_aws_creds_src }}"

--- a/tasks/credentials_azure.yml
+++ b/tasks/credentials_azure.yml
@@ -1,0 +1,9 @@
+- name: Create destination directory for Azure Credentials
+  file:
+    state: directory
+    dest: "{{ ocp_install_azure_creds_dest | dirname }}"
+
+- name: Install Azure Credentials for openshift-install
+  copy:
+    src: "{{ ocp_install_azure_creds_file }}"
+    dest: "{{ ocp_install_azure_creds_src }}"

--- a/tasks/credentials_gcp.yml
+++ b/tasks/credentials_gcp.yml
@@ -1,0 +1,9 @@
+- name: Create destination directory for GCP Credentials
+  file:
+    state: directory
+    dest: "{{ ocp_install_gcp_creds_dest | dirname }}"
+
+- name: Install GCP Credentials for openshift-install
+  copy:
+    src: "{{ ocp_install_gcp_creds_file }}"
+    dest: "{{ ocp_install_gcp_creds_src }}"

--- a/tasks/credentials_openstack.yml
+++ b/tasks/credentials_openstack.yml
@@ -1,0 +1,9 @@
+- name: Create destination directory for Openstack Credentials
+  file:
+    state: directory
+    dest: "{{ ocp_install_openstack_creds_dest | dirname }}"
+
+- name: Install Openstack Credentials for openshift-install
+  copy:
+    src: "{{ ocp_install_openstack_creds_file }}"
+    dest: "{{ ocp_install_openstack_creds_src }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,5 +33,11 @@
     - include_tasks: destroy_cluster.yml
       when: ocp_install_destroy_cluster
 
+    - include_tasks: create_manifests.yml
+      when: ocp_install_create_manifests
+
+    - include_tasks: create_ignition_configs.yml
+      when: ocp_install_create_ignition_configs
+
   become: "{{ ocp_install_become }}"
   become_user: "{{ ocp_install_become_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,18 @@
     - include_tasks: generate_config.yml
       when: ocp_install_generate_config
 
+    - include_tasks: credentials_aws.yml
+      when: ocp_install_aws_creds_file is defined
+
+    - include_tasks: credentials_azure.yml
+      when: ocp_install_azure_creds_file is defined
+
+    - include_tasks: credentials_gcp.yml
+      when: ocp_install_gcp_creds_file is defined
+
+    - include_tasks: credentials_openstack.yml
+      when: ocp_install_openstack_creds_file is defined
+
     - name: Calculate async retries
       set_fact:
         ocp_install_async_retries: >-

--- a/tasks/validation.yml
+++ b/tasks/validation.yml
@@ -4,7 +4,12 @@
 - name: Ensure config is generated when running installer
   set_fact:
     ocp_install_generate_config: true
-  when: ocp_install_create_cluster
+  # All of these commands require a config to be generated prior
+  # to running to prevent users being prompted during the run.
+  when: >
+    ocp_install_create_cluster or
+    ocp_install_create_manifests or
+    ocp_install_create_ignition_configs
 
 - name: Check required vars for downloading installer
   assert:


### PR DESCRIPTION
Closes #5 by adding support for creating manifests and ignition configs. Also brings in a commit that adds support for putting credentials files for cloud providers where `openshift-install` expects them to be (along with docs for how they're expected to be formatted).